### PR TITLE
[🐛 Fix] 간편 회원가입 시 로직 오류 개선

### DIFF
--- a/src/pages/KakaoCallbackPage.tsx
+++ b/src/pages/KakaoCallbackPage.tsx
@@ -27,7 +27,7 @@ const KakaoCallbackPage = () => {
 
       if (!code) {
         showSnack('카카오 인증에 실패했습니다.', 'error', {
-          onClose: () => navigate('/login'),
+          onClose: () => navigate('/login', { replace: true }),
         });
         return;
       }
@@ -58,20 +58,20 @@ const KakaoCallbackPage = () => {
             'success',
             { duration: 1500 }
           );
-          navigate('/');
+          navigate('/', { replace: true });
         } else {
           // 로그인 모드
           const response = await http.post('/oauth/sign-in/kakao', requestData);
 
           token.setTokens(response.data.accessToken, response.data.refreshToken);
           showSnack('로그인에 성공했습니다.', 'success');
-          navigate('/');
+          navigate('/', { replace: true });
         }
       } catch (error) {
         if (isAxiosError(error) && error.response?.status === 403 && !isKakaoSignUpMode) {
           // 로그인 모드에서 가입되지 않은 사용자
           showSnack('가입되지 않은 사용자입니다. 회원가입을 진행해주세요.', 'error', {
-            onClose: () => navigate('/signup'),
+            onClose: () => navigate('/signup', { replace: true }),
           });
         } else {
           // 에러 시 세션 정리
@@ -83,7 +83,7 @@ const KakaoCallbackPage = () => {
               : '카카오 처리에 실패했습니다.';
 
           showSnack(errorMessage, 'error', { duration: 1000 });
-          navigate('/login');
+          navigate('/login', { replace: true });
         }
       } finally {
         setIsLoading(false);


### PR DESCRIPTION
## ✅ PR 체크리스트

### 1. 코드 & 기능

- [x] 기능 정상 동작
- [x] 콘솔 에러 없음

## 🔗 이슈 번호

- close #170 

## 🎯 작업한 내용

- 간편회원가입 이후 중복되는 리다이랙트를 막아 잘못된 스낵바가 뜨는 현상을 개선함

## 🫧 참고사항

- 간편 회원가입 이후 로그인 화면을 거치지 않고 메인으로 바로 이동함
